### PR TITLE
added a way to register animations from other resources

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -130,6 +130,16 @@ exports('initiate', function()
         customprop = val
     end
 
+    Animations.registerAnimation = function(name, animation)
+        Anims[name] = animation
+    end
+
+    Animations.registerAnimations = function(animationTables)
+        for name, animation in pairs(animationTables) do
+            Anims[name] = animation
+        end
+    end
+
     return Animations
 end)
 


### PR DESCRIPTION
Many mods could benefit from the functions of **vorp_animations**, but since they should open a pull request for every new animations they need they usually go by creating their own animation code.

An easy solution to this would be adding an export that could help in registering new animations at run time like this.

```lua
local Animations = exports.vorp_animations.initiate()

Animations.registerAnimations({
    ["simple_pickup"] = {
        dict = "amb_work@world_human_box_pickup@1@male_a@stand_exit_withprop",
        name = "exit_front",
        type = 'standard',
        flag = 1,
    },

    ["wood_cut"] = {
        dict = "amb_work@world_human_tree_chop_new@working@pre_swing@male_a@trans",
        name = "pre_swing_trans_after_swing",
        type = 'standard',
        flag = 1,
        prop = {
            model = 'p_axe02x',
            coords = {
                x = -0.03,
                y = -0.02,
                z = -0.29,
                xr = 176,
                yr = 3,
                zr = 234
            },
            bone = 'SKEL_L_Finger13',
        }
    },
});
```

In this way every resource could add their own animations to vorp_animations and make the most out of vorp_animations (and also use the devtools on their animations) without the need to touch vorp_animations' code.

This PR has already been tested with some custom animations and it seems to be working fine.